### PR TITLE
Add support for merge queues and tweak dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*        @NewDayTechnology/Principals
-*.csproj @NewDayTechnology/Principals @dependabot
+*       @NewDayTechnology/Principals

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*       @NewDayTechnology/Principals
+*        @NewDayTechnology/Principals
+*.csproj @NewDayTechnology/Principals @dependabot

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directory: "/"
     schedule:
       interval: "daily"
-      time: "08:00"
+      time: "06:00"
       timezone: "Europe/London"
     labels:
       - ":game_die: dependencies"
       - ":robot: bot"
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: "Moq" ## avoid Moq 4.20+
+      ## avoid Moq 4.20+
+      - dependency-name: "Moq"
+      ## Preserve backward compatibility for library consumers
       - dependency-name: "FluentValidation"
       - dependency-name: "FluentValidation.DependencyInjectionExtensions"
+      - dependency-name: "Microsoft.Azure.WebJobs.Extensions.OpenApi.Core"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
     tags: [ "**" ]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,9 +20,3 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Auto approve patch updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,15 +15,14 @@ jobs:
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
+      - name: Enable auto squash-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Auto approve patch updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      


### PR DESCRIPTION
- Allow dependabot to enable auto merge for patch updates, but still require approval
- Preserve backward compatibility for library consumers
- Add support for merge queues 