### PR TITLE
Workflows tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -25,16 +25,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.0.x
     - name: Build
-      run: dotnet build
+      run: dotnet build --no-incremental
     - name: Test
-      run: dotnet test --no-build --verbosity normal
-
+      run: dotnet test --no-build --verbosity normal --logger trx --results-directory "TestResults"
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      with:
+        name: dotnet-results
+        path: TestResults
+      if: ${{ always() }}
   pack:
     runs-on: ubuntu-latest
     needs: 
@@ -43,7 +48,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 23 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    # Avoid running for Draft pull requests
+    if: github.event.pull_request.draft == false
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: 'csharp'
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Build
+      run: dotnet build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,13 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   schedule:
+    # Run every week, at a randomly picked time and day
     - cron: '16 23 * * 4'
 
 jobs:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
       - reopened
       - labeled
       - unlabeled

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -8,11 +8,11 @@ on:
       - unlabeled
 
 jobs:
-  check_labels:
+  check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for "do-not-merge" label
-        if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+      - name: Check for "do not merge" label
+        if: contains(github.event.pull_request.labels.*.name, 'do not merge')
         run: |
           echo "This PR should not be merged."
           exit 1

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
       - reopened
       - labeled
       - unlabeled

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
       - labeled
       - unlabeled
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,18 @@
+name: Check PR Labels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for "do-not-merge" label
+        if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+        run: |
+          echo "This PR should not be merged."
+          exit 1


### PR DESCRIPTION
- Moved CodeQL scan to an explicit workflow, based on official GitHub template with following tweaks
  - Avoid run for draft PRs and add trigger on ready for review
  - Use .NET build directly, instead of relying on CodeQL autobuild which incur extra ~30s
- Upload Test results as build artifact
- Add a check to prevent merging PRs with `do not merge` label